### PR TITLE
fix(robots): permitir crawl de URLs com ?skuId= para Google Merchant

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -105,7 +105,6 @@ Disallow: /*?PS=
 Disallow: /*&PS=
 Disallow: /*?sc=
 Disallow: /*&sc=
-Disallow: /*?skuId=
 Disallow: /*?workspace=
 
 # --- VTEX commerce paths ---


### PR DESCRIPTION
## Problema

A regra `Disallow: /*?skuId=` bloqueia o Googlebot de rastrear as landing pages enviadas pelo connector nativo VTEX → Google Merchant Center. O connector envia 1 entrada por SKU com `link = /p?skuId=N` (variant selection parameter). Robots.txt bloqueando esse parâmetro = produto reprovado no Merchant.

## Mudança

Remove apenas a linha `Disallow: /*?skuId=`. Todas as outras regras permanecem intactas.

## Referências

- https://support.google.com/merchants/answer/12467444 (How to fix: Unable to do quality & policy checks)
- https://support.google.com/merchants/answer/6324416 (Link [link] — variant selection na URL)
- https://github.com/deco-sites/notta/pull/164 (caso original — notta, já mergeado)
