### PR TITLE
chore: replace legacy asset URLs with decoims.com

### DIFF
--- a/.deco/blocks/Footer.json
+++ b/.deco/blocks/Footer.json
@@ -1,6 +1,6 @@
 {
   "__resolveType": "site/sections/FooterSection.tsx",
-  "rightDecoration": "https://assets.decocache.com/carcaralanding/763313fd-824b-47c1-96a9-a3bdc3979f10/carc-mob.svg",
+  "rightDecoration": "https://decoims.com/carcaralanding/763313fd-824b-47c1-96a9-a3bdc3979f10/carc-mob.svg",
   "transformationStoriesColumn": {
     "posts": {
       "__resolveType": "blog/loaders/BlogpostList.ts",

--- a/.deco/blocks/collections%2Fblog%2Fposts%2F20b19a742159.json
+++ b/.deco/blocks/collections%2Fblog%2Fposts%2F20b19a742159.json
@@ -7,12 +7,12 @@
     "extraProps": [
       {
         "key": "logoBrand",
-        "value": "https://assets.decocache.com/carcaralanding/1588b405-48b6-4cc6-ab56-d55624a4b5c9/farm2.svg"
+        "value": "https://decoims.com/carcaralanding/1588b405-48b6-4cc6-ab56-d55624a4b5c9/farm2.svg"
       }
     ],
     "excerpt": "Solução também garantiu um site 40x mais rápido que a solução legado",
     "title": "Nossa Implementação na Farm Rio aumentou 27% da receita mensal da marca",
-    "image": "https://assets.decocache.com/carcaralanding/90b9a050-c0cd-4e73-9065-54b98a7e4a18/cases-04.png",
+    "image": "https://decoims.com/carcaralanding/90b9a050-c0cd-4e73-9065-54b98a7e4a18/cases-04.png",
     "slug": "/farmrio",
     "date": "2025-03-21",
     "content": "<p></p>"

--- a/.deco/blocks/collections%2Fblog%2Fposts%2Fb3c4af02117d.json
+++ b/.deco/blocks/collections%2Fblog%2Fposts%2Fb3c4af02117d.json
@@ -7,17 +7,17 @@
     "extraProps": [
       {
         "key": "logoBrand",
-        "value": "https://assets.decocache.com/carcaralanding/cd95d249-4020-439e-b339-0e39527d751f/als.svg"
+        "value": "https://decoims.com/carcaralanding/cd95d249-4020-439e-b339-0e39527d751f/als.svg"
       }
     ],
     "title": "Als Sports ganha crescimento de receita 50% acima do esperado",
     "excerpt": "A nova solução permitiu à equipe implementar recursos específicos e melhorias que antes eram impossíveis ou exigiriam um grande investimento em desenvolvimento de software.",
-    "image": "https://assets.decocache.com/carcaralanding/1a26a3f6-3dd2-439e-b8f1-e19b6a057fcd/cases-01.png",
+    "image": "https://decoims.com/carcaralanding/1a26a3f6-3dd2-439e-b8f1-e19b6a057fcd/cases-01.png",
     "slug": "/als",
     "date": "2025-03-11",
     "content": "<p></p>",
     "seo": {
-      "image": "https://assets.decocache.com/carcaralanding/cd95d249-4020-439e-b339-0e39527d751f/als.svg"
+      "image": "https://decoims.com/carcaralanding/cd95d249-4020-439e-b339-0e39527d751f/als.svg"
     }
   }
 }

--- a/.deco/blocks/collections%2Fblog%2Fposts%2Fc1c248f6bfab.json
+++ b/.deco/blocks/collections%2Fblog%2Fposts%2Fc1c248f6bfab.json
@@ -7,7 +7,7 @@
     "extraProps": [
       {
         "key": "logoBrand",
-        "value": "https://assets.decocache.com/carcaralanding/2394b6ef-0530-4cf8-aa2b-7967c23b6217/leroylogo.svg"
+        "value": "https://decoims.com/carcaralanding/2394b6ef-0530-4cf8-aa2b-7967c23b6217/leroylogo.svg"
       }
     ],
     "title": "Leroy Merlin ganha produtividade substituindo 3 ferramentas pelo nosso CMS",
@@ -15,9 +15,9 @@
     "slug": "/leroy",
     "content": "<p></p>",
     "date": "2025-03-20",
-    "image": "https://assets.decocache.com/carcaralanding/a90cf32d-011e-4b7c-93d7-ea2bc1a1e9a3/cases-03.png",
+    "image": "https://decoims.com/carcaralanding/a90cf32d-011e-4b7c-93d7-ea2bc1a1e9a3/cases-03.png",
     "seo": {
-      "image": "https://assets.decocache.com/carcaralanding/2394b6ef-0530-4cf8-aa2b-7967c23b6217/leroylogo.svg"
+      "image": "https://decoims.com/carcaralanding/2394b6ef-0530-4cf8-aa2b-7967c23b6217/leroylogo.svg"
     }
   }
 }

--- a/.deco/blocks/collections%2Fblog%2Fposts%2Ff7c837b2c0e6.json
+++ b/.deco/blocks/collections%2Fblog%2Fposts%2Ff7c837b2c0e6.json
@@ -7,12 +7,12 @@
     "extraProps": [
       {
         "key": "logoBrand",
-        "value": "https://assets.decocache.com/carcaralanding/3bb48b86-2924-4dc3-a9ce-3dcb3caab032/livemode.svg"
+        "value": "https://decoims.com/carcaralanding/3bb48b86-2924-4dc3-a9ce-3dcb3caab032/livemode.svg"
       }
     ],
     "title": "Livemode constrói seu próprio Photoshop",
     "excerpt": "Saiba como a Livemode, parceira da Cazé TV, está criando material gráficos para suas transmissões 100x mais rápido com 40 AI Agents diferentes.",
-    "image": "https://assets.decocache.com/carcaralanding/326511af-9a10-4211-99d9-5e05564ce626/cases-02.png",
+    "image": "https://decoims.com/carcaralanding/326511af-9a10-4211-99d9-5e05564ce626/cases-02.png",
     "alt": "livemode-photoshop",
     "slug": "/livemode",
     "content": "<p>Saiba como a Livemode, parceira da Cazé TV, está criando material gráficos para suas transmissões 100x mais rápido com 40 AI Agents diferentes.</p>",

--- a/.deco/blocks/navbar.json
+++ b/.deco/blocks/navbar.json
@@ -2,11 +2,11 @@
   "__resolveType": "site/sections/HeaderSection.tsx",
   "logo": {
     "desktop": {
-      "src": "https://assets.decocache.com/carcaralanding/2a0428e3-b1e8-428c-a220-4e4b9b837529/carc.svg",
+      "src": "https://decoims.com/carcaralanding/2a0428e3-b1e8-428c-a220-4e4b9b837529/carc.svg",
       "alt": "carcara-logo"
     },
     "mobile": {
-      "src": "https://assets.decocache.com/carcaralanding/763313fd-824b-47c1-96a9-a3bdc3979f10/carc-mob.svg",
+      "src": "https://decoims.com/carcaralanding/763313fd-824b-47c1-96a9-a3bdc3979f10/carc-mob.svg",
       "alt": "carcara-logo"
     }
   },

--- a/.deco/blocks/pages-Enrich%2520CRM%2520AI%2520Agent-535751.json
+++ b/.deco/blocks/pages-Enrich%2520CRM%2520AI%2520Agent-535751.json
@@ -13,10 +13,10 @@
       "section": {
         "__resolveType": "site/sections/AgentHero.tsx",
         "backgroundElement1": {
-          "image": "https://assets.decocache.com/carcaralanding/a8151278-2db9-4cc2-9fdc-59298e2a3387/red-bg-hero.svg"
+          "image": "https://decoims.com/carcaralanding/a8151278-2db9-4cc2-9fdc-59298e2a3387/red-bg-hero.svg"
         },
         "backgroundElement2": {
-          "image": "https://assets.decocache.com/carcaralanding/f56e7a4b-da65-4591-8487-cfda4c53a60f/gray-bg-hero.svg"
+          "image": "https://decoims.com/carcaralanding/f56e7a4b-da65-4591-8487-cfda4c53a60f/gray-bg-hero.svg"
         },
         "conversation": [
           {
@@ -63,8 +63,8 @@
             "accentColor": "bg-verde",
             "name": "Whatsapp",
             "description": "Atendimento automatizado 24/7 com respostas personalizadas para seus clientes via WhatsApp.",
-            "interfacePreview": "https://assets.decocache.com/carcaralanding/84928d22-8b9b-4fd0-a598-f5054fe724f2/whatsapp-crm.png",
-            "icon": "https://assets.decocache.com/carcaralanding/fe7af92a-45f7-4eeb-9b31-0267c54a0c52/whatsapp.svg"
+            "interfacePreview": "https://decoims.com/carcaralanding/84928d22-8b9b-4fd0-a598-f5054fe724f2/whatsapp-crm.png",
+            "icon": "https://decoims.com/carcaralanding/fe7af92a-45f7-4eeb-9b31-0267c54a0c52/whatsapp.svg"
           },
           {
             "benefits": [
@@ -76,8 +76,8 @@
             "accentColor": "bg-azul",
             "name": "Slack",
             "description": "Respostas instantâneas e automação de fluxos de trabalho para sua equipe direto no Slack.",
-            "interfacePreview": "https://assets.decocache.com/carcaralanding/7d5b0046-9704-476d-8bd1-5ad9037e72a1/slack-crm.png",
-            "icon": "https://assets.decocache.com/carcaralanding/94cb3c75-917d-4182-bbbe-46c45de1bb54/slack.svg"
+            "interfacePreview": "https://decoims.com/carcaralanding/7d5b0046-9704-476d-8bd1-5ad9037e72a1/slack-crm.png",
+            "icon": "https://decoims.com/carcaralanding/94cb3c75-917d-4182-bbbe-46c45de1bb54/slack.svg"
           },
           {
             "benefits": [
@@ -89,8 +89,8 @@
             "accentColor": "bg-vermelho",
             "name": "Microsoft Teams",
             "description": "Integração perfeita com Teams para colaboração e suporte à tomada de decisões empresariais.",
-            "interfacePreview": "https://assets.decocache.com/carcaralanding/c53535ca-d038-47d4-a8a9-76a606ccfd94/teams-crm.png",
-            "icon": "https://assets.decocache.com/carcaralanding/1f32749d-89b2-4623-8a89-ff0a2e66d6b0/teams.svg"
+            "interfacePreview": "https://decoims.com/carcaralanding/c53535ca-d038-47d4-a8a9-76a606ccfd94/teams-crm.png",
+            "icon": "https://decoims.com/carcaralanding/1f32749d-89b2-4623-8a89-ff0a2e66d6b0/teams.svg"
           }
         ]
       }
@@ -106,7 +106,7 @@
       "__resolveType": "website/sections/Rendering/Lazy.tsx",
       "section": {
         "__resolveType": "site/sections/ImageTextSection.tsx",
-        "image": "https://assets.decocache.com/carcaralanding/6944984a-2d47-4ca9-9ad7-5c266d25f22e/context-crm.png",
+        "image": "https://decoims.com/carcaralanding/6944984a-2d47-4ca9-9ad7-5c266d25f22e/context-crm.png",
         "badgeText": "Integrações MCP",
         "title": "<p>Agente Sempre <span style=\"color: #b13431\">Contextualizado</span></p>",
         "description": "Conecte-se facilmente via API REST ou GraphQL — ou escolha entre mais de 100 integrações prontas. Compartilhe recursos e consultas com segurança entre equipes, de forma simples e eficiente"

--- a/.deco/blocks/pages-Home%2520-%2520EN-925302.json
+++ b/.deco/blocks/pages-Home%2520-%2520EN-925302.json
@@ -8,10 +8,10 @@
         "__resolveType": "site/sections/HeaderSection.tsx",
         "logo": {
           "desktop": {
-            "src": "https://assets.decocache.com/carcaralanding/2a0428e3-b1e8-428c-a220-4e4b9b837529/carc.svg"
+            "src": "https://decoims.com/carcaralanding/2a0428e3-b1e8-428c-a220-4e4b9b837529/carc.svg"
           },
           "mobile": {
-            "src": "https://assets.decocache.com/carcaralanding/763313fd-824b-47c1-96a9-a3bdc3979f10/carc-mob.svg"
+            "src": "https://decoims.com/carcaralanding/763313fd-824b-47c1-96a9-a3bdc3979f10/carc-mob.svg"
           }
         },
         "navigation": {
@@ -46,43 +46,43 @@
       "section": {
         "__resolveType": "site/sections/HeroSection.tsx",
         "backgroundElement1": {
-          "image": "https://assets.decocache.com/carcaralanding/a8151278-2db9-4cc2-9fdc-59298e2a3387/red-bg-hero.svg"
+          "image": "https://decoims.com/carcaralanding/a8151278-2db9-4cc2-9fdc-59298e2a3387/red-bg-hero.svg"
         },
         "showBackgroundElements": true,
         "title": "<h1>We build</h1><h1><span style=\"color: rgb(177, 52, 49)\">AI</span> <span style=\"color: rgb(177, 52, 49)\">Agents</span></h1><h1>for your company</h1>",
         "backgroundElement2": {
-          "image": "https://assets.decocache.com/carcaralanding/f56e7a4b-da65-4591-8487-cfda4c53a60f/gray-bg-hero.svg",
+          "image": "https://decoims.com/carcaralanding/f56e7a4b-da65-4591-8487-cfda4c53a60f/gray-bg-hero.svg",
           "configCarousel": {}
         },
         "ctaHref": "https://calendar.app.google/VvgENxewXsBNjXPF7",
-        "image": "https://assets.decocache.com/carcaralanding/c9cd5eae-9038-4899-9a92-141198822a4c/hero-image-agents.png",
+        "image": "https://decoims.com/carcaralanding/c9cd5eae-9038-4899-9a92-141198822a4c/hero-image-agents.png",
         "ctaText": "Get in touch with us",
         "configCarousel": {
           "items": [
             {
               "id": "2",
-              "imageUrl": "https://assets.decocache.com/carcaralanding/de006fd8-174f-4502-827f-45e4d6080c48/hero-contentagent.png",
+              "imageUrl": "https://decoims.com/carcaralanding/de006fd8-174f-4502-827f-45e4d6080c48/hero-contentagent.png",
               "title": "Content Analyzer AI Agent",
               "subtitle": "123123",
               "duration": "4"
             },
             {
               "id": "3",
-              "imageUrl": "https://assets.decocache.com/carcaralanding/e9b3f07a-a745-4e69-9105-062edf41c13e/hero-seoagent.png",
+              "imageUrl": "https://decoims.com/carcaralanding/e9b3f07a-a745-4e69-9105-062edf41c13e/hero-seoagent.png",
               "title": "SEO AI Agent",
               "subtitle": "123123",
               "duration": "4"
             },
             {
               "id": "4",
-              "imageUrl": "https://assets.decocache.com/carcaralanding/7a1c130f-370c-43f3-811d-44eec2cc5eaa/hero-vtexaiagent.png",
+              "imageUrl": "https://decoims.com/carcaralanding/7a1c130f-370c-43f3-811d-44eec2cc5eaa/hero-vtexaiagent.png",
               "title": "VTEX AI Agent",
               "subtitle": "123123",
               "duration": "4"
             },
             {
               "id": "5",
-              "imageUrl": "https://assets.decocache.com/carcaralanding/0307a1ad-562d-4dc1-8660-9178219568c4/hero-whatsappagent.png",
+              "imageUrl": "https://decoims.com/carcaralanding/0307a1ad-562d-4dc1-8660-9178219568c4/hero-whatsappagent.png",
               "title": "WhatsApp AI Agent",
               "subtitle": "123123",
               "duration": "4"
@@ -109,47 +109,47 @@
         "__resolveType": "site/sections/Logos.tsx",
         "logos": [
           {
-            "src": "https://assets.decocache.com/carcaralanding/6ba87d40-56a6-4589-bad6-7b0869880436/ZeeDog.svg",
+            "src": "https://decoims.com/carcaralanding/6ba87d40-56a6-4589-bad6-7b0869880436/ZeeDog.svg",
             "altText": "zeedog"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/d44b9be7-10c8-49fd-b06d-cdce137996dc/torra.svg",
+            "src": "https://decoims.com/carcaralanding/d44b9be7-10c8-49fd-b06d-cdce137996dc/torra.svg",
             "altText": "torra"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/0d36379f-7590-4753-ac22-66bf8329b9d2/osklen.svg",
+            "src": "https://decoims.com/carcaralanding/0d36379f-7590-4753-ac22-66bf8329b9d2/osklen.svg",
             "altText": "osklen"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/3fb9d2ef-d917-4d97-b3dd-ade75045a9b0/Miess.svg",
+            "src": "https://decoims.com/carcaralanding/3fb9d2ef-d917-4d97-b3dd-ade75045a9b0/Miess.svg",
             "altText": "miess"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/3bb48b86-2924-4dc3-a9ce-3dcb3caab032/livemode.svg",
+            "src": "https://decoims.com/carcaralanding/3bb48b86-2924-4dc3-a9ce-3dcb3caab032/livemode.svg",
             "altText": "livemode"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/2394b6ef-0530-4cf8-aa2b-7967c23b6217/leroylogo.svg",
+            "src": "https://decoims.com/carcaralanding/2394b6ef-0530-4cf8-aa2b-7967c23b6217/leroylogo.svg",
             "altText": "leroymerlin"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/3c644eff-1b32-4022-bf61-85412298d045/CVLB.svg",
+            "src": "https://decoims.com/carcaralanding/3c644eff-1b32-4022-bf61-85412298d045/CVLB.svg",
             "altText": "cvl"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/18e0e935-95fc-4026-9d28-51f61c2fc21b/BAW.svg",
+            "src": "https://decoims.com/carcaralanding/18e0e935-95fc-4026-9d28-51f61c2fc21b/BAW.svg",
             "altText": "baw"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/1588b405-48b6-4cc6-ab56-d55624a4b5c9/farm2.svg",
+            "src": "https://decoims.com/carcaralanding/1588b405-48b6-4cc6-ab56-d55624a4b5c9/farm2.svg",
             "altText": "farm"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/cd95d249-4020-439e-b339-0e39527d751f/als.svg",
+            "src": "https://decoims.com/carcaralanding/cd95d249-4020-439e-b339-0e39527d751f/als.svg",
             "altText": "als"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/f5e68d4d-4ebc-411b-8e96-9436a0e0bfa7/reserva.svg"
+            "src": "https://decoims.com/carcaralanding/f5e68d4d-4ebc-411b-8e96-9436a0e0bfa7/reserva.svg"
           }
         ]
       }
@@ -208,7 +208,7 @@
         "title": "The impact we've made on our clients",
         "badgeText": "Our success stories",
         "featuredStory": {
-          "image": "https://assets.decocache.com/carcaralanding/90b9a050-c0cd-4e73-9065-54b98a7e4a18/cases-04.png",
+          "image": "https://decoims.com/carcaralanding/90b9a050-c0cd-4e73-9065-54b98a7e4a18/cases-04.png",
           "title": "Our implementation at Farm Rio increased the brand's monthly revenue by 27%.",
           "description": "The solution also delivered a website 40x faster than the legacy system.",
           "showButton": false,
@@ -217,15 +217,15 @@
         "additionalStories": [
           {
             "accentColor": "\"amarelo\"",
-            "image": "https://assets.decocache.com/carcaralanding/a90cf32d-011e-4b7c-93d7-ea2bc1a1e9a3/cases-03.png",
-            "logo": "https://assets.decocache.com/carcaralanding/2394b6ef-0530-4cf8-aa2b-7967c23b6217/leroylogo.svg",
+            "image": "https://decoims.com/carcaralanding/a90cf32d-011e-4b7c-93d7-ea2bc1a1e9a3/cases-03.png",
+            "logo": "https://decoims.com/carcaralanding/2394b6ef-0530-4cf8-aa2b-7967c23b6217/leroylogo.svg",
             "title": "Leroy Merlin increased productivity by replacing 3 tools with our CMS."
           },
           {
             "accentColor": "\"amarelo\"",
             "title": "Livemode builds its own Photoshop.",
-            "image": "https://assets.decocache.com/carcaralanding/326511af-9a10-4211-99d9-5e05564ce626/cases-02.png",
-            "logo": "https://assets.decocache.com/carcaralanding/3bb48b86-2924-4dc3-a9ce-3dcb3caab032/livemode.svg",
+            "image": "https://decoims.com/carcaralanding/326511af-9a10-4211-99d9-5e05564ce626/cases-02.png",
+            "logo": "https://decoims.com/carcaralanding/3bb48b86-2924-4dc3-a9ce-3dcb3caab032/livemode.svg",
             "showButton": false,
             "buttonText": "oi",
             "buttonUrl": "j"
@@ -233,8 +233,8 @@
           {
             "accentColor": "\"amarelo\"",
             "title": "Als Sports achieves revenue growth 50% above expectations",
-            "image": "https://assets.decocache.com/carcaralanding/1a26a3f6-3dd2-439e-b8f1-e19b6a057fcd/cases-01.png",
-            "logo": "https://assets.decocache.com/carcaralanding/cd95d249-4020-439e-b339-0e39527d751f/als.svg"
+            "image": "https://decoims.com/carcaralanding/1a26a3f6-3dd2-439e-b8f1-e19b6a057fcd/cases-01.png",
+            "logo": "https://decoims.com/carcaralanding/cd95d249-4020-439e-b339-0e39527d751f/als.svg"
           }
         ]
       }
@@ -256,7 +256,7 @@
             "title": "Generative CMS",
             "subtitle": "Intelligent and scalable content",
             "description": "Transform your content creation with a system that automatically generates, manages, and optimizes texts, maintaining your brand identity and significantly increasing your productivity.",
-            "image": "https://assets.decocache.com/carcaralanding/16543901-125b-4d53-ae3f-45e4afd1a782/cms.png",
+            "image": "https://decoims.com/carcaralanding/16543901-125b-4d53-ae3f-45e4afd1a782/cms.png",
             "buttonLink": "https://calendar.app.google/VvgENxewXsBNjXPF7",
             "showButton": false
           },
@@ -264,7 +264,7 @@
             "title": "SEO Agents",
             "subtitle": "Strategic visibility",
             "description": "Our SEO agents continuously analyze your market, optimize your content, and implement strategies that increase your organic visibility, bringing the right audience to your business.",
-            "image": "https://assets.decocache.com/carcaralanding/6cd390e0-8c8b-4e93-99ef-f4e021c79ca2/seo.png",
+            "image": "https://decoims.com/carcaralanding/6cd390e0-8c8b-4e93-99ef-f4e021c79ca2/seo.png",
             "buttonLink": "https://calendar.app.google/VvgENxewXsBNjXPF7",
             "showButton": false
           },
@@ -272,7 +272,7 @@
             "title": "AI Creative Suite",
             "subtitle": "Creativity without limits",
             "description": "Generate brand-aligned images, texts, and designs in seconds. Our creative suite eliminates production bottlenecks and allows you to scale your visual communication with consistency and quality.",
-            "image": "https://assets.decocache.com/carcaralanding/25a88b43-b9e7-4749-825a-f9f849d02bd0/creative.png",
+            "image": "https://decoims.com/carcaralanding/25a88b43-b9e7-4749-825a-f9f849d02bd0/creative.png",
             "buttonLink": "https://calendar.app.google/VvgENxewXsBNjXPF7",
             "showButton": false
           },
@@ -280,7 +280,7 @@
             "title": "AI Video Content Intelligence",
             "subtitle": "Videos that convert",
             "description": "Transform how you produce, analyze, and optimize video content. Our technology identifies engagement patterns, extracts valuable insights, and suggests improvements that increase conversions.",
-            "image": "https://assets.decocache.com/carcaralanding/8a779fdf-c9f5-4580-aac7-f0789019cab5/video.png",
+            "image": "https://decoims.com/carcaralanding/8a779fdf-c9f5-4580-aac7-f0789019cab5/video.png",
             "buttonLink": "https://calendar.app.google/VvgENxewXsBNjXPF7",
             "showButton": false
           },
@@ -288,7 +288,7 @@
             "title": "AI Data Scientist",
             "subtitle": "Data that decides",
             "description": "Have an AI data scientist working 24/7, transforming complex information into clear and actionable insights. Make data-driven decisions without needing a specialized team.",
-            "image": "https://assets.decocache.com/carcaralanding/9954af22-987f-497d-ba1f-caefaed47e33/data.png",
+            "image": "https://decoims.com/carcaralanding/9954af22-987f-497d-ba1f-caefaed47e33/data.png",
             "buttonLink": "https://calendar.app.google/VvgENxewXsBNjXPF7",
             "showButton": false
           },
@@ -296,14 +296,14 @@
             "title": "AI WhatsApp Assistant",
             "subtitle": "Intelligent service",
             "description": "An assistant that understands the context of conversations, solves complex problems, and communicates naturally with your customers, providing personalized service at scale.",
-            "image": "https://assets.decocache.com/carcaralanding/a7f6857b-b8b9-4d99-bd39-7ae2f5d41519/whatsapp.png",
+            "image": "https://decoims.com/carcaralanding/a7f6857b-b8b9-4d99-bd39-7ae2f5d41519/whatsapp.png",
             "buttonLink": "https://calendar.app.google/VvgENxewXsBNjXPF7",
             "showButton": false
           },
           {
             "buttonText": "Learn more",
             "title": "AI Agent VTEX",
-            "image": "https://assets.decocache.com/carcaralanding/7c8d0db2-1c44-4e3c-9448-73fe95941490/vtexaiagent.png",
+            "image": "https://decoims.com/carcaralanding/7c8d0db2-1c44-4e3c-9448-73fe95941490/vtexaiagent.png",
             "subtitle": "Manage the growth of your VTEX operation",
             "description": "Have a specialist from your VTEX operation working alongside you. Gain stock insights, analyze your sales performance, and receive strategic recommendations to increase revenue.",
             "buttonLink": "https://carcara.tech/vtex-ai-agent",
@@ -328,23 +328,23 @@
         "__resolveType": "site/sections/MethodologySection.tsx",
         "discoveryBox": {
           "title": "1. Definition",
-          "image": "https://assets.decocache.com/carcaralanding/cb79053f-97cf-4276-b929-9747d4b9d817/3.png",
+          "image": "https://decoims.com/carcaralanding/cb79053f-97cf-4276-b929-9747d4b9d817/3.png",
           "description": "We dive into your business to identify high-impact opportunities, analyzing processes, data, and specific challenges to determine the ideal solution for your needs."
         },
         "ctaUrl": "https://calendar.app.google/VvgENxewXsBNjXPF7",
         "prototypingBox": {
           "title": "2. Prototyping",
-          "image": "https://assets.decocache.com/carcaralanding/f85a5f8e-c585-4b88-a9e9-c618b8736a34/1.png",
+          "image": "https://decoims.com/carcaralanding/f85a5f8e-c585-4b88-a9e9-c618b8736a34/1.png",
           "description": "We develop a functional solution in days, allowing you to validate the real impact before making larger investments and adjust the direction based on concrete results."
         },
         "implementationBox": {
           "title": "3. Implementation",
           "description": "We integrate the solution into your existing infrastructure, with integration to your legacy tools, training your team, and continuous monitoring to maximize return.",
-          "image": "https://assets.decocache.com/carcaralanding/cb79053f-97cf-4276-b929-9747d4b9d817/3.png"
+          "image": "https://decoims.com/carcaralanding/cb79053f-97cf-4276-b929-9747d4b9d817/3.png"
         },
         "ctaText": "Learn more about our services",
         "analysisBox": {
-          "image": "https://assets.decocache.com/carcaralanding/f86e1da5-62ef-43e6-b071-7c7356306ef2/4.png"
+          "image": "https://decoims.com/carcaralanding/f86e1da5-62ef-43e6-b071-7c7356306ef2/4.png"
         },
         "title": "Methodology focused on quick results",
         "badgeText": "How we work"
@@ -448,7 +448,7 @@
       "section": {
         "__resolveType": "site/sections/CTASection.tsx",
         "title": "Ready to evolve your company?",
-        "backgroundImage": "https://assets.decocache.com/carcaralanding/22b1cbb0-d23f-477e-9769-147101117551/cta.svg",
+        "backgroundImage": "https://decoims.com/carcaralanding/22b1cbb0-d23f-477e-9769-147101117551/cta.svg",
         "buttonUrl": "https://calendar.app.google/VvgENxewXsBNjXPF7",
         "subtitle": "Get in touch to secure your personalized AI Agent",
         "buttonText": "Schedule a meeting"
@@ -458,7 +458,7 @@
       "__resolveType": "website/sections/Rendering/Lazy.tsx",
       "section": {
         "__resolveType": "site/sections/FooterSection.tsx",
-        "rightDecoration": "https://assets.decocache.com/carcaralanding/763313fd-824b-47c1-96a9-a3bdc3979f10/carc-mob.svg",
+        "rightDecoration": "https://decoims.com/carcaralanding/763313fd-824b-47c1-96a9-a3bdc3979f10/carc-mob.svg",
         "transformationStoriesColumn": {
           "posts": {
             "__resolveType": "blog/loaders/BlogpostList.ts",

--- a/.deco/blocks/pages-Home-964833.json
+++ b/.deco/blocks/pages-Home-964833.json
@@ -8,10 +8,10 @@
         "__resolveType": "site/sections/HeaderSection.tsx",
         "logo": {
           "desktop": {
-            "src": "https://assets.decocache.com/carcaralanding/2a0428e3-b1e8-428c-a220-4e4b9b837529/carc.svg"
+            "src": "https://decoims.com/carcaralanding/2a0428e3-b1e8-428c-a220-4e4b9b837529/carc.svg"
           },
           "mobile": {
-            "src": "https://assets.decocache.com/carcaralanding/763313fd-824b-47c1-96a9-a3bdc3979f10/carc-mob.svg"
+            "src": "https://decoims.com/carcaralanding/763313fd-824b-47c1-96a9-a3bdc3979f10/carc-mob.svg"
           }
         },
         "navigation": {
@@ -46,43 +46,43 @@
       "section": {
         "__resolveType": "site/sections/HeroSection.tsx",
         "backgroundElement1": {
-          "image": "https://assets.decocache.com/carcaralanding/a8151278-2db9-4cc2-9fdc-59298e2a3387/red-bg-hero.svg"
+          "image": "https://decoims.com/carcaralanding/a8151278-2db9-4cc2-9fdc-59298e2a3387/red-bg-hero.svg"
         },
         "showBackgroundElements": true,
         "title": "<h1>Construímos</h1><h1><span style=\"color: rgb(177, 52, 49)\">AI</span> <span style=\"color: rgb(177, 52, 49)\">Agents</span></h1><h1>para sua empresa</h1>",
         "backgroundElement2": {
-          "image": "https://assets.decocache.com/carcaralanding/f56e7a4b-da65-4591-8487-cfda4c53a60f/gray-bg-hero.svg",
+          "image": "https://decoims.com/carcaralanding/f56e7a4b-da65-4591-8487-cfda4c53a60f/gray-bg-hero.svg",
           "configCarousel": {}
         },
         "ctaHref": "https://calendar.app.google/VvgENxewXsBNjXPF7",
-        "image": "https://assets.decocache.com/carcaralanding/c9cd5eae-9038-4899-9a92-141198822a4c/hero-image-agents.png",
+        "image": "https://decoims.com/carcaralanding/c9cd5eae-9038-4899-9a92-141198822a4c/hero-image-agents.png",
         "ctaText": "Entre em contato conosco",
         "configCarousel": {
           "items": [
             {
               "id": "2",
-              "imageUrl": "https://assets.decocache.com/carcaralanding/dbca0255-39c6-44c0-8da7-c75771c9af01/hero-contentagent.png",
+              "imageUrl": "https://decoims.com/carcaralanding/dbca0255-39c6-44c0-8da7-c75771c9af01/hero-contentagent.png",
               "title": "Content Analyzer AI Agent",
               "subtitle": "123123",
               "duration": "4"
             },
             {
               "id": "3",
-              "imageUrl": "https://assets.decocache.com/carcaralanding/5b92de4f-c2be-4529-84c4-444b98c39c09/hero-seoagent.png",
+              "imageUrl": "https://decoims.com/carcaralanding/5b92de4f-c2be-4529-84c4-444b98c39c09/hero-seoagent.png",
               "title": "SEO AI Agent",
               "subtitle": "123123",
               "duration": "4"
             },
             {
               "id": "4",
-              "imageUrl": "https://assets.decocache.com/carcaralanding/0af3b685-0b82-403b-9bd1-03b263ee247e/hero-vtexaiagent.png",
+              "imageUrl": "https://decoims.com/carcaralanding/0af3b685-0b82-403b-9bd1-03b263ee247e/hero-vtexaiagent.png",
               "title": "VTEX AI Agent",
               "subtitle": "123123",
               "duration": "4"
             },
             {
               "id": "5",
-              "imageUrl": "https://assets.decocache.com/carcaralanding/47be7401-5483-46a9-8d93-2253258f43da/hero-whatsappagent.png",
+              "imageUrl": "https://decoims.com/carcaralanding/47be7401-5483-46a9-8d93-2253258f43da/hero-whatsappagent.png",
               "title": "WhatsApp AI Agent",
               "subtitle": "123123",
               "duration": "4"
@@ -108,47 +108,47 @@
         "__resolveType": "site/sections/Logos.tsx",
         "logos": [
           {
-            "src": "https://assets.decocache.com/carcaralanding/6ba87d40-56a6-4589-bad6-7b0869880436/ZeeDog.svg",
+            "src": "https://decoims.com/carcaralanding/6ba87d40-56a6-4589-bad6-7b0869880436/ZeeDog.svg",
             "altText": "zeedog"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/d44b9be7-10c8-49fd-b06d-cdce137996dc/torra.svg",
+            "src": "https://decoims.com/carcaralanding/d44b9be7-10c8-49fd-b06d-cdce137996dc/torra.svg",
             "altText": "torra"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/0d36379f-7590-4753-ac22-66bf8329b9d2/osklen.svg",
+            "src": "https://decoims.com/carcaralanding/0d36379f-7590-4753-ac22-66bf8329b9d2/osklen.svg",
             "altText": "osklen"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/3fb9d2ef-d917-4d97-b3dd-ade75045a9b0/Miess.svg",
+            "src": "https://decoims.com/carcaralanding/3fb9d2ef-d917-4d97-b3dd-ade75045a9b0/Miess.svg",
             "altText": "miess"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/3bb48b86-2924-4dc3-a9ce-3dcb3caab032/livemode.svg",
+            "src": "https://decoims.com/carcaralanding/3bb48b86-2924-4dc3-a9ce-3dcb3caab032/livemode.svg",
             "altText": "livemode"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/2394b6ef-0530-4cf8-aa2b-7967c23b6217/leroylogo.svg",
+            "src": "https://decoims.com/carcaralanding/2394b6ef-0530-4cf8-aa2b-7967c23b6217/leroylogo.svg",
             "altText": "leroymerlin"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/3c644eff-1b32-4022-bf61-85412298d045/CVLB.svg",
+            "src": "https://decoims.com/carcaralanding/3c644eff-1b32-4022-bf61-85412298d045/CVLB.svg",
             "altText": "cvl"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/18e0e935-95fc-4026-9d28-51f61c2fc21b/BAW.svg",
+            "src": "https://decoims.com/carcaralanding/18e0e935-95fc-4026-9d28-51f61c2fc21b/BAW.svg",
             "altText": "baw"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/1588b405-48b6-4cc6-ab56-d55624a4b5c9/farm2.svg",
+            "src": "https://decoims.com/carcaralanding/1588b405-48b6-4cc6-ab56-d55624a4b5c9/farm2.svg",
             "altText": "farm"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/cd95d249-4020-439e-b339-0e39527d751f/als.svg",
+            "src": "https://decoims.com/carcaralanding/cd95d249-4020-439e-b339-0e39527d751f/als.svg",
             "altText": "als"
           },
           {
-            "src": "https://assets.decocache.com/carcaralanding/f5e68d4d-4ebc-411b-8e96-9436a0e0bfa7/reserva.svg"
+            "src": "https://decoims.com/carcaralanding/f5e68d4d-4ebc-411b-8e96-9436a0e0bfa7/reserva.svg"
           }
         ]
       }
@@ -236,7 +236,7 @@
             "title": "AI Agent VTEX",
             "subtitle": "Gerencie o crescimento da sua operação VTEX",
             "description": "Tenha um especialista da sua operação VTEX trabalhando ao seu lado. Tenha insights de estoque, analise a performance das suas vendas e ganhe recomendações estratégicas para aumentar receita.",
-            "image": "https://assets.decocache.com/carcaralanding/7c8d0db2-1c44-4e3c-9448-73fe95941490/vtexaiagent.png",
+            "image": "https://decoims.com/carcaralanding/7c8d0db2-1c44-4e3c-9448-73fe95941490/vtexaiagent.png",
             "buttonLink": "https://carcara.tech/vtex-ai-agent",
             "showButton": true,
             "buttonText": "Saiba mais"
@@ -245,7 +245,7 @@
             "title": "AI WhatsApp Assistant",
             "subtitle": "Atendimento inteligente",
             "description": "Um assistente que entende o contexto das conversas, resolve problemas complexos e se comunica naturalmente com seus clientes, proporcionando atendimento personalizado em escala.",
-            "image": "https://assets.decocache.com/carcaralanding/a7f6857b-b8b9-4d99-bd39-7ae2f5d41519/whatsapp.png",
+            "image": "https://decoims.com/carcaralanding/a7f6857b-b8b9-4d99-bd39-7ae2f5d41519/whatsapp.png",
             "buttonLink": "https://carcara.tech/whatsapp-agents",
             "showButton": true
           },
@@ -253,7 +253,7 @@
             "title": "AI Creative Suite",
             "subtitle": "Criatividade sem limites",
             "description": "Gere imagens, textos e designs alinhados com sua marca em segundos. Nossa suite criativa elimina gargalos de produção e permite que você escale sua comunicação visual com consistência e qualidade.",
-            "image": "https://assets.decocache.com/carcaralanding/25a88b43-b9e7-4749-825a-f9f849d02bd0/creative.png",
+            "image": "https://decoims.com/carcaralanding/25a88b43-b9e7-4749-825a-f9f849d02bd0/creative.png",
             "buttonLink": "https://calendar.app.google/VvgENxewXsBNjXPF7",
             "showButton": false
           },
@@ -261,7 +261,7 @@
             "title": "AI Data Scientist",
             "subtitle": "Dados que decidem",
             "description": "Tenha um cientista de dados AI que trabalha 24/7, transformando informações complexas em insights claros e acionáveis. Tome decisões baseadas em dados sem precisar de uma equipe especializada.",
-            "image": "https://assets.decocache.com/carcaralanding/9954af22-987f-497d-ba1f-caefaed47e33/data.png",
+            "image": "https://decoims.com/carcaralanding/9954af22-987f-497d-ba1f-caefaed47e33/data.png",
             "buttonLink": "https://calendar.app.google/VvgENxewXsBNjXPF7",
             "showButton": false
           },
@@ -269,7 +269,7 @@
             "title": "CMS Generativo",
             "subtitle": "Conteúdo inteligente e escalável",
             "description": "Transforme sua criação de conteúdo com um sistema que gera, gerencia e otimiza textos automaticamente, mantendo sua identidade de marca e aumentando significativamente sua produtividade.",
-            "image": "https://assets.decocache.com/carcaralanding/16543901-125b-4d53-ae3f-45e4afd1a782/cms.png",
+            "image": "https://decoims.com/carcaralanding/16543901-125b-4d53-ae3f-45e4afd1a782/cms.png",
             "buttonLink": "https://calendar.app.google/VvgENxewXsBNjXPF7",
             "showButton": false
           },
@@ -277,13 +277,13 @@
             "title": "Agentes de SEO",
             "subtitle": "Visibilidade estratégica",
             "description": "Nossos agentes de SEO analisam continuamente seu mercado, otimizam seu conteúdo e implementam estratégias que aumentam sua visibilidade orgânica, trazendo o público certo para seu negócio.",
-            "image": "https://assets.decocache.com/carcaralanding/6cd390e0-8c8b-4e93-99ef-f4e021c79ca2/seo.png",
+            "image": "https://decoims.com/carcaralanding/6cd390e0-8c8b-4e93-99ef-f4e021c79ca2/seo.png",
             "buttonLink": "https://calendar.app.google/VvgENxewXsBNjXPF7",
             "showButton": false
           },
           {
             "title": "AI Video Content Intelligence",
-            "image": "https://assets.decocache.com/carcaralanding/8a779fdf-c9f5-4580-aac7-f0789019cab5/video.png",
+            "image": "https://decoims.com/carcaralanding/8a779fdf-c9f5-4580-aac7-f0789019cab5/video.png",
             "subtitle": "Vídeos que convertem",
             "description": "Transforme como você produz, analisa e otimiza conteúdo em vídeo. Nossa tecnologia identifica padrões de engajamento, extrai insights valiosos e sugere melhorias que aumentam conversões.",
             "buttonLink": "https://calendar.app.google/VvgENxewXsBNjXPF7",
@@ -308,21 +308,21 @@
         "__resolveType": "site/sections/MethodologySection.tsx",
         "discoveryBox": {
           "title": "1. Definição",
-          "image": "https://assets.decocache.com/carcaralanding/cb79053f-97cf-4276-b929-9747d4b9d817/3.png"
+          "image": "https://decoims.com/carcaralanding/cb79053f-97cf-4276-b929-9747d4b9d817/3.png"
         },
         "ctaUrl": "https://calendar.app.google/VvgENxewXsBNjXPF7",
         "prototypingBox": {
           "title": "2. Prototipagem",
-          "image": "https://assets.decocache.com/carcaralanding/f85a5f8e-c585-4b88-a9e9-c618b8736a34/1.png"
+          "image": "https://decoims.com/carcaralanding/f85a5f8e-c585-4b88-a9e9-c618b8736a34/1.png"
         },
         "implementationBox": {
           "title": "3. Implementação",
           "description": "Integramos a solução à sua infraestrutura existente, com integração às suas ferramentas legado, treinamento da sua equipe e monitoramento contínuo para maximizar o retorno.",
-          "image": "https://assets.decocache.com/carcaralanding/cb79053f-97cf-4276-b929-9747d4b9d817/3.png"
+          "image": "https://decoims.com/carcaralanding/cb79053f-97cf-4276-b929-9747d4b9d817/3.png"
         },
         "ctaText": "Conheça mais nossos serviços",
         "analysisBox": {
-          "image": "https://assets.decocache.com/carcaralanding/f86e1da5-62ef-43e6-b071-7c7356306ef2/4.png"
+          "image": "https://decoims.com/carcaralanding/f86e1da5-62ef-43e6-b071-7c7356306ef2/4.png"
         }
       }
     },
@@ -421,7 +421,7 @@
       "__resolveType": "website/sections/Rendering/Lazy.tsx",
       "section": {
         "__resolveType": "site/sections/CTASection.tsx",
-        "backgroundImage": "https://assets.decocache.com/carcaralanding/22b1cbb0-d23f-477e-9769-147101117551/cta.svg",
+        "backgroundImage": "https://decoims.com/carcaralanding/22b1cbb0-d23f-477e-9769-147101117551/cta.svg",
         "buttonUrl": "https://calendar.app.google/VvgENxewXsBNjXPF7",
         "title": "Pronto para evoluir sua empresa?",
         "subtitle": "Entre em contato para conquistar seu AI Agent personalizado"

--- a/.deco/blocks/pages-SAC%2520AI%2520Agent-870171.json
+++ b/.deco/blocks/pages-SAC%2520AI%2520Agent-870171.json
@@ -13,10 +13,10 @@
       "section": {
         "__resolveType": "site/sections/AgentHero.tsx",
         "backgroundElement1": {
-          "image": "https://assets.decocache.com/carcaralanding/a8151278-2db9-4cc2-9fdc-59298e2a3387/red-bg-hero.svg"
+          "image": "https://decoims.com/carcaralanding/a8151278-2db9-4cc2-9fdc-59298e2a3387/red-bg-hero.svg"
         },
         "backgroundElement2": {
-          "image": "https://assets.decocache.com/carcaralanding/f56e7a4b-da65-4591-8487-cfda4c53a60f/gray-bg-hero.svg"
+          "image": "https://decoims.com/carcaralanding/f56e7a4b-da65-4591-8487-cfda4c53a60f/gray-bg-hero.svg"
         },
         "conversation": [
           {
@@ -53,8 +53,8 @@
             "accentColor": "bg-verde",
             "name": "Whatsapp",
             "description": "Atendimento automatizado 24/7 com respostas personalizadas para seus clientes via WhatsApp.",
-            "interfacePreview": "https://assets.decocache.com/carcaralanding/26e81ae9-2fff-48c5-864f-c27d76e32ecd/whatsapp-sac.png",
-            "icon": "https://assets.decocache.com/carcaralanding/fe7af92a-45f7-4eeb-9b31-0267c54a0c52/whatsapp.svg"
+            "interfacePreview": "https://decoims.com/carcaralanding/26e81ae9-2fff-48c5-864f-c27d76e32ecd/whatsapp-sac.png",
+            "icon": "https://decoims.com/carcaralanding/fe7af92a-45f7-4eeb-9b31-0267c54a0c52/whatsapp.svg"
           },
           {
             "benefits": [
@@ -66,8 +66,8 @@
             "accentColor": "bg-azul",
             "name": "Slack",
             "description": "Respostas instantâneas e automação de fluxos de trabalho para sua equipe direto no Slack.",
-            "interfacePreview": "https://assets.decocache.com/carcaralanding/3628a08a-63e5-417e-ae00-2704dae1dbc5/slack-sac.png",
-            "icon": "https://assets.decocache.com/carcaralanding/94cb3c75-917d-4182-bbbe-46c45de1bb54/slack.svg"
+            "interfacePreview": "https://decoims.com/carcaralanding/3628a08a-63e5-417e-ae00-2704dae1dbc5/slack-sac.png",
+            "icon": "https://decoims.com/carcaralanding/94cb3c75-917d-4182-bbbe-46c45de1bb54/slack.svg"
           },
           {
             "benefits": [
@@ -79,8 +79,8 @@
             "accentColor": "bg-vermelho",
             "name": "Microsoft Teams",
             "description": "Integração perfeita com Teams para colaboração e suporte à tomada de decisões empresariais.",
-            "interfacePreview": "https://assets.decocache.com/carcaralanding/a9b6117f-c3a1-4341-bf2f-ee2a60367d46/teams-sac.png",
-            "icon": "https://assets.decocache.com/carcaralanding/1f32749d-89b2-4623-8a89-ff0a2e66d6b0/teams.svg"
+            "interfacePreview": "https://decoims.com/carcaralanding/a9b6117f-c3a1-4341-bf2f-ee2a60367d46/teams-sac.png",
+            "icon": "https://decoims.com/carcaralanding/1f32749d-89b2-4623-8a89-ff0a2e66d6b0/teams.svg"
           }
         ]
       }
@@ -96,7 +96,7 @@
       "__resolveType": "website/sections/Rendering/Lazy.tsx",
       "section": {
         "__resolveType": "site/sections/ImageTextSection.tsx",
-        "image": "https://assets.decocache.com/carcaralanding/edc5dad8-cb9c-4b74-85f8-601caa237773/sacint.png",
+        "image": "https://decoims.com/carcaralanding/edc5dad8-cb9c-4b74-85f8-601caa237773/sacint.png",
         "badgeText": "Integrações MCP",
         "title": "<p>Agente Sempre <span style=\"color: #b13431\">Contextualizado</span></p>",
         "description": "Conecte-se facilmente via API REST ou GraphQL — ou escolha entre mais de 100 integrações prontas. Compartilhe recursos e consultas com segurança entre equipes, de forma simples e eficiente"

--- a/.deco/blocks/pages-VTEX%2520AI%2520Agent-170241.json
+++ b/.deco/blocks/pages-VTEX%2520AI%2520Agent-170241.json
@@ -8,13 +8,13 @@
     {
       "__resolveType": "site/sections/VtexAgentHero.tsx",
       "backgroundElement1": {
-        "image": "https://assets.decocache.com/carcaralanding/a8151278-2db9-4cc2-9fdc-59298e2a3387/red-bg-hero.svg"
+        "image": "https://decoims.com/carcaralanding/a8151278-2db9-4cc2-9fdc-59298e2a3387/red-bg-hero.svg"
       },
       "backgroundElement2": {
-        "image": "https://assets.decocache.com/carcaralanding/f56e7a4b-da65-4591-8487-cfda4c53a60f/gray-bg-hero.svg"
+        "image": "https://decoims.com/carcaralanding/f56e7a4b-da65-4591-8487-cfda4c53a60f/gray-bg-hero.svg"
       },
       "title": "<p>Converse com a sua<span style=\"color: #b13431\"> loja VTEX</span></p>",
-      "chatIcon": "https://assets.decocache.com/carcaralanding/527d8e8a-e055-4335-ab6f-51ba323f3edf/vtex-logo-carcara-03.png",
+      "chatIcon": "https://decoims.com/carcaralanding/527d8e8a-e055-4335-ab6f-51ba323f3edf/vtex-logo-carcara-03.png",
       "primaryCtaHref": "https://calendar.app.google/VvgENxewXsBNjXPF7"
     },
     {
@@ -41,9 +41,9 @@
               "Automação de processos de venda e pós-venda"
             ],
             "builtinIcon": "WhatsApp",
-            "interfacePreview": "https://assets.decocache.com/carcaralanding/a02b16d2-6015-475b-aad6-f2147400b977/whatsapp.png",
+            "interfacePreview": "https://decoims.com/carcaralanding/a02b16d2-6015-475b-aad6-f2147400b977/whatsapp.png",
             "accentColor": "bg-verde",
-            "icon": "https://assets.decocache.com/carcaralanding/0f8100b6-3905-45c6-8095-2b47cfb0dcf6/whatsapp.svg"
+            "icon": "https://decoims.com/carcaralanding/0f8100b6-3905-45c6-8095-2b47cfb0dcf6/whatsapp.svg"
           },
           {
             "name": "Slack",
@@ -54,9 +54,9 @@
               "Integração com outras ferramentas da empresa"
             ],
             "customIcon": "slack",
-            "interfacePreview": "https://assets.decocache.com/carcaralanding/52611d4d-e7ff-40d3-9a27-328b12c1efa0/slack.png",
+            "interfacePreview": "https://decoims.com/carcaralanding/52611d4d-e7ff-40d3-9a27-328b12c1efa0/slack.png",
             "accentColor": "bg-azul",
-            "icon": "https://assets.decocache.com/carcaralanding/6f5fd620-e236-466d-bfb7-b51719463425/slack.svg"
+            "icon": "https://decoims.com/carcaralanding/6f5fd620-e236-466d-bfb7-b51719463425/slack.svg"
           },
           {
             "name": "Microsoft Teams",
@@ -67,9 +67,9 @@
               "Pesquisa de dados e documentos corporativos"
             ],
             "customIcon": "teams",
-            "interfacePreview": "https://assets.decocache.com/carcaralanding/385a6f03-fc3e-4f8f-b118-25acfe31e410/teams.png",
+            "interfacePreview": "https://decoims.com/carcaralanding/385a6f03-fc3e-4f8f-b118-25acfe31e410/teams.png",
             "accentColor": "bg-vermelho",
-            "icon": "https://assets.decocache.com/carcaralanding/8dd18346-b98a-42ec-bb61-619bb3c79486/teams.svg"
+            "icon": "https://decoims.com/carcaralanding/8dd18346-b98a-42ec-bb61-619bb3c79486/teams.svg"
           },
           {
             "name": "Admin deco.cx",
@@ -80,9 +80,9 @@
               "Sugestões de melhorias baseadas em dados"
             ],
             "customIcon": "deco",
-            "interfacePreview": "https://assets.decocache.com/carcaralanding/9922c0b4-c76f-42b3-a703-181cfaf52bd9/deco.png",
+            "interfacePreview": "https://decoims.com/carcaralanding/9922c0b4-c76f-42b3-a703-181cfaf52bd9/deco.png",
             "accentColor": "bg-amarelo",
-            "icon": "https://assets.decocache.com/carcaralanding/d14e4282-f516-4d05-8821-e5410cb9d10a/deco.svg"
+            "icon": "https://decoims.com/carcaralanding/d14e4282-f516-4d05-8821-e5410cb9d10a/deco.svg"
           }
         ],
         "backgroundElement": {
@@ -147,7 +147,7 @@
             "icon": "people"
           }
         ],
-        "budgetBackgroundImage": "https://assets.decocache.com/carcaralanding/22b1cbb0-d23f-477e-9769-147101117551/cta.svg"
+        "budgetBackgroundImage": "https://decoims.com/carcaralanding/22b1cbb0-d23f-477e-9769-147101117551/cta.svg"
       }
     },
     {
@@ -214,7 +214,7 @@
       "__resolveType": "website/sections/Rendering/Lazy.tsx",
       "section": {
         "__resolveType": "site/sections/CTASection.tsx",
-        "backgroundImage": "https://assets.decocache.com/carcaralanding/22b1cbb0-d23f-477e-9769-147101117551/cta.svg",
+        "backgroundImage": "https://decoims.com/carcaralanding/22b1cbb0-d23f-477e-9769-147101117551/cta.svg",
         "buttonUrl": "https://calendar.app.google/VvgENxewXsBNjXPF7",
         "title": "Pronto para evoluir sua empresa?",
         "subtitle": "Entre em contato para conquistar seu AI Agent personalizado"
@@ -224,7 +224,7 @@
       "__resolveType": "website/sections/Rendering/Lazy.tsx",
       "section": {
         "__resolveType": "site/sections/FooterSection.tsx",
-        "rightDecoration": "https://assets.decocache.com/carcaralanding/763313fd-824b-47c1-96a9-a3bdc3979f10/carc-mob.svg",
+        "rightDecoration": "https://decoims.com/carcaralanding/763313fd-824b-47c1-96a9-a3bdc3979f10/carc-mob.svg",
         "transformationStoriesColumn": {
           "posts": {
             "__resolveType": "blog/loaders/BlogpostList.ts",

--- a/.deco/blocks/pages-WhatsApp%2520Agents-847120.json
+++ b/.deco/blocks/pages-WhatsApp%2520Agents-847120.json
@@ -13,10 +13,10 @@
       "section": {
         "__resolveType": "site/sections/WppHero.tsx",
         "backgroundElement1": {
-          "image": "https://assets.decocache.com/carcaralanding/f3233981-030b-49d7-bf55-b8dba9788110/wpp.svg"
+          "image": "https://decoims.com/carcaralanding/f3233981-030b-49d7-bf55-b8dba9788110/wpp.svg"
         },
         "backgroundElement2": {
-          "image": "https://assets.decocache.com/carcaralanding/f56e7a4b-da65-4591-8487-cfda4c53a60f/gray-bg-hero.svg"
+          "image": "https://decoims.com/carcaralanding/f56e7a4b-da65-4591-8487-cfda4c53a60f/gray-bg-hero.svg"
         },
         "title": "<p>Escale seu atendimento usando <span style=\"color: #557247\">WhatsApp</span></p>",
         "primaryCtaText": "Marcar Demo",
@@ -34,7 +34,7 @@
       "__resolveType": "website/sections/Rendering/Lazy.tsx",
       "section": {
         "__resolveType": "site/sections/ImageTextSection.tsx",
-        "image": "https://assets.decocache.com/carcaralanding/edc5dad8-cb9c-4b74-85f8-601caa237773/sacint.png",
+        "image": "https://decoims.com/carcaralanding/edc5dad8-cb9c-4b74-85f8-601caa237773/sacint.png",
         "badgeText": "Integrações MCP",
         "title": "<p>Agente Sempre <span style=\"color: #b13431\">Contextualizado</span></p>",
         "description": "Conecte-se facilmente via API REST ou GraphQL — ou escolha entre mais de 100 integrações prontas. Compartilhe recursos e consultas com segurança entre equipes, de forma simples e eficiente"
@@ -127,7 +127,7 @@
       "__resolveType": "website/sections/Rendering/Lazy.tsx",
       "section": {
         "__resolveType": "site/sections/CTASection.tsx",
-        "backgroundImage": "https://assets.decocache.com/carcaralanding/22b1cbb0-d23f-477e-9769-147101117551/cta.svg",
+        "backgroundImage": "https://decoims.com/carcaralanding/22b1cbb0-d23f-477e-9769-147101117551/cta.svg",
         "title": "Pronto para escalar seu atendimento?"
       }
     },

--- a/.deco/blocks/site.json
+++ b/.deco/blocks/site.json
@@ -5,8 +5,8 @@
     "jsonLDs": [],
     "noIndexing": true,
     "description": "Nossos projetos fazem a ponte entre o desafio de negócio e um AI Agent que dá resultado.",
-    "favicon": "https://assets.decocache.com/carcaralanding/8948f588-bdb2-4bd6-afe7-e68d8cad49c9/faviconcarcara.svg",
-    "image": "https://assets.decocache.com/carcaralanding/059baa65-18d1-4b8d-80bb-0f20d698418f/seocarcara.png",
+    "favicon": "https://decoims.com/carcaralanding/8948f588-bdb2-4bd6-afe7-e68d8cad49c9/faviconcarcara.svg",
+    "image": "https://decoims.com/carcaralanding/059baa65-18d1-4b8d-80bb-0f20d698418f/seocarcara.png",
     "titleTemplate": "%s",
     "descriptionTemplate": "%s"
   },


### PR DESCRIPTION
## Migração de assets legados

Substitui todas as referências de:
- `assets.decocache.com` → `decoims.com`
- `data.decoassets.com` → `decoims.com`

**13 arquivo(s) alterado(s):**
- `.deco/blocks/site.json`
- `.deco/blocks/collections%2Fblog%2Fposts%2Fb3c4af02117d.json`
- `.deco/blocks/Footer.json`
- `.deco/blocks/pages-WhatsApp%2520Agents-847120.json`
- `.deco/blocks/collections%2Fblog%2Fposts%2Fc1c248f6bfab.json`
- `.deco/blocks/pages-Enrich%2520CRM%2520AI%2520Agent-535751.json`
- `.deco/blocks/pages-Home-964833.json`
- `.deco/blocks/collections%2Fblog%2Fposts%2Ff7c837b2c0e6.json`
- `.deco/blocks/pages-VTEX%2520AI%2520Agent-170241.json`
- `.deco/blocks/collections%2Fblog%2Fposts%2F20b19a742159.json`
- `.deco/blocks/navbar.json`
- `.deco/blocks/pages-SAC%2520AI%2520Agent-870171.json`
- `.deco/blocks/pages-Home%2520-%2520EN-925302.json`